### PR TITLE
Altimeter thousands cosmetic fix

### DIFF
--- a/Models/Instruments/PFD/pfd.xml
+++ b/Models/Instruments/PFD/pfd.xml
@@ -659,6 +659,7 @@
 		<type>number-value</type>
 		<property alias="../../params/indicated-altitude-ft" />
 		<scale>0.001</scale>
+		<offset>0.025</offset>
 		<truncate type="bool">true</truncate>
 		<axis-alignment>yz-plane</axis-alignment>
 		<alignment>right-center</alignment>


### PR DESCRIPTION
Make the thousands field of the PFD altimeter strip flip over 25ft below the 000 point. This avoid misleading readings close to 000. E.g., when pressure altitude is 7999 ft, the alitmeter would read "7" in the thousands field, and the "000" from the strip would be almost exactly centered inside the marker, so one would misread this as 7000 ft, when really it's 8000. So we add a small margin.

It's still not ideal; the best solution would be to actually have the thousands digit move through the transition (i.e., within a range of 7000 +/- 25 ft, the thousands digit would be offset vertically), but IMO this is better than the previous situation.