### PR TITLE
Fix fwd / ctr cargo doors

### DIFF
--- a/Models/CRJ1000.xml
+++ b/Models/CRJ1000.xml
@@ -380,7 +380,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>
@@ -437,7 +437,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>
@@ -464,7 +464,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>25</dep>
+				<dep>30</dep>
 			</entry>
 		</interpolation>
 		<center>

--- a/Models/CRJ700.xml
+++ b/Models/CRJ700.xml
@@ -371,7 +371,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>

--- a/Models/CRJ900.xml
+++ b/Models/CRJ900.xml
@@ -370,7 +370,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>
@@ -427,7 +427,7 @@
 			</entry>
 			<entry>
 				<ind>1</ind>
-				<dep>-0.5</dep>
+				<dep>-0.1</dep>
 			</entry>
 		</interpolation>
 		<axis>


### PR DESCRIPTION
Fwd and Center Cargo doors were offset too much, making them hover under the aircraft belly when open. This fixes the offset so that the doors move nicely around the fuselage, just like the aft cargo bay door (but down rather than up).