### PR TITLE
Make cargo bay weight influence FDM weights

### DIFF
--- a/CRJ1000.xml
+++ b/CRJ1000.xml
@@ -172,5 +172,7 @@
         <weight x="14.94" y="0.0" z="-1.0" mass-prop="/sim/weight[0]/weight-lb" solve-weight="1" idx="0" />
         <!-- PAX/Cargo -->
         <weight x="3.5" y="0.0" z="-1.0" mass-prop="/sim/weight[1]/weight-lb" solve-weight="1" idx="1" />
+        <weight x="5" y="0.0" z="-2.0" mass-prop="/sim/weight[2]/weight-lb" solve-weight="1" idx="2" />
+        <weight x="-5" y="0.0" z="-2.0" mass-prop="/sim/weight[3]/weight-lb" solve-weight="1" idx="3" />
 
 </airplane>

--- a/CRJ1000ER.xml
+++ b/CRJ1000ER.xml
@@ -172,5 +172,7 @@
         <weight x="14.94" y="0.0" z="-1.0" mass-prop="/sim/weight[0]/weight-lb" solve-weight="1" idx="0" />
         <!-- PAX/Cargo -->
         <weight x="3.5" y="0.0" z="-1.0" mass-prop="/sim/weight[1]/weight-lb" solve-weight="1" idx="1" />
+        <weight x="5" y="0.0" z="-2.0" mass-prop="/sim/weight[2]/weight-lb" solve-weight="1" idx="2" />
+        <weight x="-5" y="0.0" z="-2.0" mass-prop="/sim/weight[3]/weight-lb" solve-weight="1" idx="3" />
 
 </airplane>


### PR DESCRIPTION
Cargo loaded in the "fuel and payload" dialog would not influence aircraft weight; as a consequence, a fully loaded CRJ1000 with maximum fuel still wouldn't get close to MTOW, which is clearly not right. Turns out cargo bay weights were not forwarded to the FDM, so this fixes it. I took a wild guess at the positions, so those may be wrong, but at least they won't influence COG too much, and the aircraft handles well when fully loaded.

I have only looked at the -1000, it's likely that the 700 and 900 also have the same problem.