### PR TITLE
Bugfix: livery files not found

### DIFF
--- a/Nasal/effects.nas
+++ b/Nasal/effects.nas
@@ -3,7 +3,8 @@
 ###########################
 
 ## Livery select
-aircraft.livery.init("Models/Liveries/" ~ getprop("sim/aircraft"));
+var model_name = "CRJ" ~ substr(getprop("sim/aircraft"), 3);
+aircraft.livery.init("Models/Liveries/" ~ model_name);
 
 ## Switch sounds
 var Switch_sound = {


### PR DESCRIPTION
For some reason, the model name in `sim` has lowercase "crj", while the livery filenames have uppercase "CRJ". AFAICT, this issue only affects platforms that have case-sensitive filenames (Linux), so Windows users will not have noticed this. It's not a nice solution, but I can't think of anything better right now.